### PR TITLE
ISS-37: Fix build publish on PR event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - develop
   pull_request:
-    braches:
+    branches:
       - develop
 
 jobs:
@@ -30,8 +30,12 @@ jobs:
           node-version: 12
           registry-url: https://registry.npmjs.org/
       - run: |
-          yarn install
-          yarn build-lib
-          yarn publish --access=public
+          if [[ $GITHUB_EVENT_NAME != "pull_request" ]]; then
+            yarn install
+            yarn build-lib
+            yarn publish --access=public
+          else
+            echo "+++++ No Publish on PR event +++++++++"
+          fi
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
## What is the Purpose?
Fix build package event trigger on PRs

Briefly describe what the PR addresses## What was the approach?
Add conditional on publish job that on `pull_request` event the publish commands should be skipped

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@michaelbukachi @andrewtpham 

## Issue(s) affected?
None
