### PR TITLE
enhancement: rework alert component to accept more props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hikaya/hakawati",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/hikaya-io/hakawati.git"

--- a/src/components/alert/HAlert.vue
+++ b/src/components/alert/HAlert.vue
@@ -1,29 +1,18 @@
 <template>
   <el-alert
     class="h-alert"
-    :title="title"
-    :type="type"
-    :description="description"
-  />
+    v-bind="$props"
+  >
+    <template v-for="(index, name) in $slots" v-slot:[name]>
+      <slot :name="name" />
+    </template>
+  </el-alert>
 </template>
 
 <script>
 export default {
   name: 'HAlert',
-  props: {
-    title: {
-      type: String,
-      default: ''
-    },
-    type: {
-      type: String,
-      default: ''
-    },
-    description: {
-      type: String,
-      default: ''
-    }
-  }
+  props: ['title', 'type', 'description', 'closable', 'show-icon', 'center', 'close-text', 'effect']
 }
 </script>
 

--- a/src/stories/Alert.stories.js
+++ b/src/stories/Alert.stories.js
@@ -20,18 +20,24 @@ export const hAlert = () => ({
       <h-alert
         title="Info alert"
         type="info"
+        center
+        closable
       />
     </div>
     <div style='margin-bottom:15px'>
       <h-alert
         title="Warning alert"
         type="warning"
+        center
+        closable
       />
     </div>
     <div style='margin-bottom:15px'>
       <h-alert
         title="Error alert"
         type="error"
+        center
+        closable
       />
     </div>
   </div>

--- a/src/stories/Alert.stories.js
+++ b/src/stories/Alert.stories.js
@@ -9,26 +9,28 @@ export const hAlert = () => ({
   template: `
   <div>
     <div style='margin-bottom:15px'>
-      <h-alert 
-        title="Success alert" 
+      <h-alert
+        title="Success alert"
         type="success"
-      /> 
+        center
+        closable
+      />
     </div>
     <div style='margin-bottom:15px'>
-      <h-alert 
-        title="Info alert" 
+      <h-alert
+        title="Info alert"
         type="info"
       />
     </div>
     <div style='margin-bottom:15px'>
-      <h-alert 
-        title="Warning alert" 
+      <h-alert
+        title="Warning alert"
         type="warning"
       />
     </div>
     <div style='margin-bottom:15px'>
-      <h-alert 
-        title="Error alert" 
+      <h-alert
+        title="Error alert"
         type="error"
       />
     </div>
@@ -77,33 +79,89 @@ export const descriptionAlert = () => ({
   template: `
   <div>
     <div style='margin-bottom:15px'>
-      <h-alert 
-        type="success" 
-        title="Alert title" 
+      <h-alert
+        type="success"
+        title="Alert title"
         description="Add description here"
       />
     </div>
     <div style='margin-bottom:15px'>
-      <h-alert 
+      <h-alert
         type="info"
-        title="Info alert" 
+        title="Info alert"
         description="Add description here"
       />
     </div>
     <div style='margin-bottom:15px'>
-    <h-alert 
+    <h-alert
         type="warning"
-        title="Warning alert" 
+        title="Warning alert"
         description="Add description here"
       />
     </div>
     <div style='margin-bottom:15px'>
-      <h-alert 
+      <h-alert
         type="error"
-        title="Error alert" 
+        title="Error alert"
         description="Add description here"
       />
     </div>
+  </div>
+      `
+})
+
+export const usingSlot = () => ({
+  components: { HAlert },
+  template: `
+  <div>
+    <div style='margin-bottom:15px'>
+      <h-alert
+        type="success"
+      >
+        <slot name="title">
+          <div>
+            The title can also be passed as a slot
+          </div>
+        </slot>
+        <slot name="description">
+          <div>
+           Something desctipion here you can use any kind of html <i>here </i>
+          </div>
+        </slot>
+      </h-alert>
+    </div>
+    <div style='margin-bottom:15px'>
+    <h-alert
+      type="info"
+    >
+      <slot name="title">
+        <div>
+          The title can also be passed as a slot
+        </div>
+      </slot>
+      <slot name="description">
+        <div>
+         Something desctipion here you can use any kind of html <i>here </i>
+        </div>
+      </slot>
+    </h-alert>
+  </div>
+  <div style='margin-bottom:15px'>
+  <h-alert
+    type="error"
+  >
+    <slot name="title">
+      <div>
+        The title can also be passed as a slot
+      </div>
+    </slot>
+    <slot name="description">
+      <div>
+       Something desctipion here you can use any kind of html <i>here </i>
+      </div>
+    </slot>
+  </h-alert>
+</div>
   </div>
       `
 })


### PR DESCRIPTION
## What is the Purpose?
Rework the h-alert component to achieve the following
- accepts all props that element supports
- title and description can be passed as slots
- fixes the issue where icons are not being rendered

## What was the approach?
- rework alert component to accept all native props

## Are there any concerns to addressed further before or after merging this PR?
N/A

## Mentions?
@ninetteadhikari 
@andrewtpham 

## Issue(s) affected?
#139 
