### PR TITLE
fix: Add table props for column headers

### DIFF
--- a/src/components/table/OldTable.vue
+++ b/src/components/table/OldTable.vue
@@ -1,33 +1,30 @@
 <template>
   <el-table
-    ref="HTable"
-    v-loading.fullscreen.lock="loading"
+    ref="multipleTable"
     @selection-change="handleSelectionChange"
     :data="tableData"
-    height="100vh"
+    :default-sort="{prop: 'date', order: 'descending'}"
+    style="width: 100%"
   >
     <el-table-column
       type="selection"
       width="55"
-      fixed
     />
-    <slot/>
+    <el-table-column
+      v-for="(value, key) in tableData[0]"
+      :prop="key"
+      :label="key.charAt(0).toUpperCase() + key.slice(1)"
+      :key="key"
+      sortable
+    >
+    </el-table-column>
   </el-table>
 </template>
 
 <script>
 export default {
-  name: 'HTable',
-  props: {
-    tableData: {
-      type: Array,
-      default: () => []
-    },
-    loading: {
-      type: Boolean,
-      default: false
-    }
-  },
+  name: 'OldTable',
+  props: ['tableData'],
   data () {
     return {
       multipleSelection: []
@@ -148,7 +145,4 @@ table {
     border-color: $primary-color;
 }
 
-.el-table--group::after, .el-table--border::after, .el-table::before{
-  background-color: transparent;
-}
 </style>

--- a/src/components/table/TableWithStatus.vue
+++ b/src/components/table/TableWithStatus.vue
@@ -1,4 +1,5 @@
 <template>
+<div class="table-with-status">
   <el-table
     :data="tableData"
     style="width: 100%"
@@ -13,6 +14,7 @@
     >
     </el-table-column>
   </el-table>
+</div>
 </template>
 
 <script>
@@ -39,7 +41,7 @@ export default {
 
 <style lang="scss">
 @import "../../styles/theme";
-
+.table-with-status{
 .el-table {
   font-family: "Lato", sans-serif;
   font-weight: 300;
@@ -57,5 +59,6 @@ export default {
 
 .el-table .success-row {
   background: #f0f9eb;
+}
 }
 </style>

--- a/src/stories/Cascader.stories.js
+++ b/src/stories/Cascader.stories.js
@@ -273,6 +273,37 @@ const options = [
   }
 ]
 
+const hOptions = [{
+  value: 'data_type',
+  label: 'Change data type',
+  children: [{
+    value: 'number',
+    label: 'Number'
+  }, {
+    value: 'string',
+    label: 'String'
+  }, {
+    value: 'datetime',
+    label: 'Datetime'
+  }, {
+    value: 'geometry',
+    label: 'Geometry'
+  }
+  ]
+}, {
+  value: 'unique_value',
+  label: 'Assign as unique'
+}, {
+  value: 'rename_column',
+  label: 'Rename column'
+}, {
+  value: 'add_column',
+  label: 'Add new column'
+}, {
+  value: 'delete_column',
+  label: 'Delete column'
+}]
+
 export const hCascader = () => ({
   components: { HCascader },
   data () {
@@ -284,6 +315,7 @@ export const hCascader = () => ({
   <h-cascader 
     :options='options'
   >
+  none
   </h-cascader>
     `
 })

--- a/src/stories/Table.stories.js
+++ b/src/stories/Table.stories.js
@@ -1,5 +1,6 @@
 import HTable from '../components/table/HTable.vue'
 import HkoboTable from '../components/table/HKoboTable.vue'
+import OldTable from '../components/table/OldTable.vue'
 import TableBasic from '../components/table/TableBasic.vue'
 import TableWithBorder from '../components/table/TableWithBorder.vue'
 import TableWithExpandableRow from '../components/table/TableWithExpandableRow.vue'
@@ -23,10 +24,34 @@ export const hTable = () => ({
   },
   data () {
     return {
+      tableData: tableDataNew
+    }
+  },
+  template: `
+  <h-table :tableData="tableData">
+  <el-table-column
+  v-for="(value, key) in tableData[0]"
+  :prop="key"
+  :label="key.charAt(0).toUpperCase() + key.slice(1)"
+  :key="key"
+  sortable
+  width="100px"
+>
+</el-table-column>
+  </h-table>
+  `
+})
+
+export const oldTable = () => ({
+  components: {
+    OldTable
+  },
+  data () {
+    return {
       tableData: tableData
     }
   },
-  template: '<h-table :tableData="tableData" />'
+  template: '<old-table :tableData="tableData" />'
 })
 
 export const hKoboTable = () => ({
@@ -210,7 +235,96 @@ const tableAccountantData = [{
 }
 ]
 
-const tableData = [{
+const tableData = [
+  {
+    date: '2020-05-03',
+    name: 'Tom',
+    state: 'California',
+    city: 'Los Angeles',
+    address: 'No. 189, Grove St, Los Angeles',
+    zip: 'CA 90036',
+    tag: 'Home'
+  },
+  {
+    date: '2020-07-02',
+    name: 'John',
+    state: 'Andalucia',
+    city: 'Malaga',
+    address: 'No. 11, Avenida, Malaga',
+    zip: 'CA 29011',
+    tag: 'Office'
+  },
+  {
+    date: '2020-07-02',
+    name: 'John',
+    state: 'Andalucia',
+    city: 'Malaga',
+    address: 'No. 11, Avenida, Malaga',
+    zip: 'CA 29011',
+    tag: 'School'
+  }
+]
+
+const tableDataNew = [{
+  date: '2020-05-03',
+  name: 'Tom',
+  state: 'California',
+  city: 'Los Angeles',
+  address: 'No. 189, Grove St, Los Angeles',
+  zip: 'CA 90036',
+  tag: 'Home',
+  a: '2020-05-03',
+  b: 'Tom',
+  c: 'California',
+  d: 'Los Angeles',
+  e: 'No. 189, Grove St, Los Angeles',
+  f: 'CA 90036',
+  g: 'Home',
+  h: '2020-05-03',
+  i: 'Tom',
+  j: 'California',
+  k: 'Los Angeles',
+  l: 'No. 189, Grove St, Los Angeles',
+  m: 'CA 90036',
+  n: 'Home'
+},
+{
+  date: '2020-07-02',
+  name: 'John',
+  state: 'Andalucia',
+  city: 'Malaga',
+  address: 'No. 11, Avenida, Malaga',
+  zip: 'CA 29011',
+  tag: 'School'
+},
+{
+  date: '2020-05-03',
+  name: 'Tom',
+  state: 'California',
+  city: 'Los Angeles',
+  address: 'No. 189, Grove St, Los Angeles',
+  zip: 'CA 90036',
+  tag: 'Home'
+},
+{
+  date: '2020-07-02',
+  name: 'John',
+  state: 'Andalucia',
+  city: 'Malaga',
+  address: 'No. 11, Avenida, Malaga',
+  zip: 'CA 29011',
+  tag: 'Office'
+},
+{
+  date: '2020-07-02',
+  name: 'John',
+  state: 'Andalucia',
+  city: 'Malaga',
+  address: 'No. 11, Avenida, Malaga',
+  zip: 'CA 29011',
+  tag: 'School'
+},
+{
   date: '2020-05-03',
   name: 'Tom',
   state: 'California',


### PR DESCRIPTION
## What is the Purpose?
Updated the Table component to include fixed columns and props for column headers
![image](https://user-images.githubusercontent.com/13760198/84932694-f947a980-b0d4-11ea-903a-5bd163a7e02d.png)

## Are there any concerns to addressed further before or after merging this PR?
- Element UI component does not allow adding additional text or dropdowns in the header column. So it will not be possible to achieve these as per wireframe:
![Screen Shot 2020-06-17 at 8 01 41 PM](https://user-images.githubusercontent.com/13760198/84933011-7c68ff80-b0d5-11ea-9ebe-21579ab57716.png)

We will have to look for alternative table elements to do these functions.
We will also have to ensure that in-line editing is supported.

This current table components is a basic one with:
- Checkbox selection of each row
- Fixed first column
- Sorting of columns

## Mentions?
@andrewtpham 

## Issue(s) affected?
None