### PR TITLE
Avoid mutating value props directly

### DIFF
--- a/src/components/select/HSelect.vue
+++ b/src/components/select/HSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <el-select
-    v-model="value"
+    v-model="selectValue"
     v-bind="$attrs"
     v-on="$listeners"
     @change="$emit('change', $event)"
@@ -19,6 +19,11 @@
 <script>
 export default {
   name: 'HSelect',
+  data () {
+    return {
+      selectValue: this.value
+    }
+  },
   props: {
     value: {
       type: [String, Number, Array],

--- a/src/components/switch/HSwitch.vue
+++ b/src/components/switch/HSwitch.vue
@@ -1,6 +1,6 @@
 <template>
   <el-switch
-    v-model="value"
+    v-model="switchValue"
     v-bind="$attrs"
     v-on="$listeners"
     @click="$emit('click')"
@@ -10,6 +10,11 @@
 <script>
 export default {
   name: 'HSwitch',
+  data () {
+    return {
+      switchValue: this.value
+    }
+  },
   props: {
     value: {
       type: Boolean,


### PR DESCRIPTION
## What is the Purpose?
The Dots frontend raises some Vue warnings when using the `HSwitch` and the `HSelect` components:

```
[Vue warn]: Avoid mutating a prop directly since the value will be overwritten whenever the parent component re-renders. Instead, use a data or computed property based on the prop's value. Prop being mutated: "value"
```

## What was the approach?
Using a second `data` field to be passed to the corresponding `v-model` attribute (See this [SO answer](https://stackoverflow.com/a/39910248/4017403))

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@michaelbukachi 

## Issue(s) affected?
None