### PR TITLE
fix: Remove duplicate options from h-select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hikaya/hakawati",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "repository": {
     "type": "git",
     "url": "https://github.com/hikaya-io/hakawati.git"

--- a/src/components/select/HSelect.vue
+++ b/src/components/select/HSelect.vue
@@ -23,14 +23,6 @@
         :value="item.value"
       />
     </template>
-    <el-option
-      v-for="item in options"
-      :key="item.value"
-      :label="item.label"
-      :disabled="item.disabled"
-      :value="item.value"
-      v-bind="optionAttributes"
-    />
   </el-select>
 </template>
 
@@ -45,10 +37,6 @@ export default {
     options: {
       type: Array,
       default: () => []
-    },
-    optionAttributes: {
-      type: Object,
-      default: () => ({})
     }
   },
   computed: {


### PR DESCRIPTION
## What is the Purpose?
Remove duplicate options from h-select

## What was the approach?
Briefly describe the approach used to address the issue

## Are there any concerns to addressed further before or after merging this PR?
State some additional info if any. For instance running `install` or setting some environment variable(s)

## Mentions?
@sannleen 

## Issue(s) affected?
Closes #211 
