### PR TITLE
Fix `h-select` elements in Storybook

### DIFF
--- a/src/stories/Select.stories.js
+++ b/src/stories/Select.stories.js
@@ -95,6 +95,7 @@ export const hSelect = () => ({
     <div>
     <p>Blank:</p>
       <h-select
+        v-model="selectedOption"
         :options="options"
         :placeholder="placeholder"
         :disabled="disabled"
@@ -132,12 +133,14 @@ export const multiSelect = () => ({
   },
   data () {
     return {
-      options
+      options,
+      selectedOption: null
     }
   },
   template: `
       <div>
         <h-select
+          v-model="selectedOption"
           :options="options"
           :collapse-tags="collapseTags"
           :placeholder="placeholder"


### PR DESCRIPTION
## What is the Purpose?
Address #215

## What was the approach?
Problem was limited to the documentation/Storybook.
The `h-select` element was missing `v-model`, hence not being able to reflect any value

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@michaelbukachi 

## Issue(s) affected?
Resolve #215