### PR TITLE
upgrade element-ui 2.15.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hikaya/hakawati",
-  "version": "0.1.54",
+  "version": "0.1.55-alpha",
   "repository": {
     "type": "git",
     "url": "https://github.com/hikaya-io/hakawati.git"
@@ -42,7 +42,7 @@
     "babel-loader": "^8.0.6",
     "babel-preset-vue": "^2.0.2",
     "cache-loader": "^4.1.0",
-    "element-ui": "^2.13.1",
+    "element-ui": "^2.15.6",
     "eslint": "^6.7.2",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-node": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7254,10 +7254,10 @@ element-resize-detector@^1.2.2:
   dependencies:
     batch-processor "1.0.0"
 
-element-ui@^2.13.1:
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/element-ui/-/element-ui-2.13.2.tgz#582bf47aaaaaafe23ea1958fae217a687ad06447"
-  integrity sha512-r761DRPssMPKDiJZWFlG+4e4vr0cRG/atKr3Eqr8Xi0tQMNbtmYU1QXvFnKiFPFFGkgJ6zS6ASkG+sellcoHlQ==
+element-ui@^2.15.6:
+  version "2.15.6"
+  resolved "https://registry.yarnpkg.com/element-ui/-/element-ui-2.15.6.tgz#c9609add35af5a686a4b7685dc1d757c75e01df3"
+  integrity sha512-rcYXEKd/j2G0AgficAOk1Zd1AsnHRkhmrK4yLHmNOiimU2JfsywgfKUjMoFuT6pQx0luhovj8lFjpE4Fnt58Iw==
   dependencies:
     async-validator "~1.8.1"
     babel-helper-vue-jsx-merge-props "^2.0.0"


### PR DESCRIPTION
## What is the Purpose?
Briefly describe what the PR addresses

## What was the approach?
- upgrade elementui from 2.13.1 --> 2.15.6 to keep dots and hakawati versions of element ui in line

## Are there any concerns to addressed further before or after merging this PR?
This is a test deployment to npm in order to test on dots FE

## Mentions?
n/a

## Issue(s) affected?
hikaya-io/dots-frontend#1344 
