### PR TITLE
Feat/custom switch

### DIFF
--- a/src/components/switch/HSwitch.vue
+++ b/src/components/switch/HSwitch.vue
@@ -51,7 +51,7 @@ export default {
 
 .h-switch-custom {
   .el-switch__core {
-    width: 200px !important;
+    width: 180px !important;
     height: 37px;
     border-radius: 20px;
     &::after {
@@ -64,7 +64,7 @@ export default {
     }
   }
   &.is-checked .el-switch__core::after {
-    left: 59%;
+    left: 52%;
     margin-left: -14px;
   }
 
@@ -81,7 +81,7 @@ export default {
 
   .el-switch__label--right {
     position: absolute;
-    left: 133px;
+    left: 110px;
   }
 }
 </style>

--- a/src/stories/Switch.stories.js
+++ b/src/stories/Switch.stories.js
@@ -89,7 +89,7 @@ export const customSwitch = () => ({
           v-model="value2"
           @change="action"
           custom-switch
-          active-text-right="120px"
+          active-text-right="100px"
           active-text-left="30px"
         >
         </h-switch>


### PR DESCRIPTION
## What is the Purpose?
Add custom switch component.
The following props are available:
- `custom-switch`: this adds the custom styling to the switch
- `active-text-left="Add value e.g. 80px"`: this adds left space to the label on the right

<img width="392" alt="image" src="https://user-images.githubusercontent.com/13760198/155041639-75632c88-536e-4496-996c-02c1d810523f.png">


## What was the approach?
Add component and story

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@andrewtpham 

## Issue(s) affected?
None
