### PR TITLE
Fix HSelect error when it is used in a form and is set to required

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hikaya/hakawati",
-  "version": "0.1.99",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/hikaya-io/hakawati.git"

--- a/src/components/select/HSelect.vue
+++ b/src/components/select/HSelect.vue
@@ -44,6 +44,10 @@
 export default {
   name: 'HSelect',
   props: {
+    value: {
+      type: [String, Number, Array, Object],
+      default: null
+    },
     options: { type: Array },
     placeholder: { type: String, default: 'Select an option' },
     grouped: { type: Boolean, default: false },
@@ -51,7 +55,17 @@ export default {
   },
   data () {
     return {
-      selectedValue: []
+      created: []
+    }
+  },
+  computed: {
+    selectedValue: {
+      get () {
+        return this.value
+      },
+      set (val) {
+        this.$emit('input', val)
+      }
     }
   },
   watch: {

--- a/src/stories/Form.stories.js
+++ b/src/stories/Form.stories.js
@@ -1,5 +1,6 @@
 import HForm from '../components/form/HForm.vue'
 import HButton from '../components/button/HButton.vue'
+import HSelect from '../components/select/HSelect.vue'
 
 // This is required for each story
 export default {
@@ -14,7 +15,7 @@ export default {
 }
 
 const Template = (args, { argTypes }) => ({
-  components: { HForm, HButton },
+  components: { HForm, HButton, HSelect },
   props: Object.keys(argTypes),
   data () {
     return {
@@ -28,6 +29,7 @@ const Template = (args, { argTypes }) => ({
         resource: '',
         desc: ''
       },
+      options: [{ label: 'Zone 1', value: 'zone_1' }, { label: 'Zone 2', value: 'zone_2' }],
       rules: {
         name: [
           { required: true, message: 'Please input Activity name', trigger: 'blur' },
@@ -79,10 +81,8 @@ const Template = (args, { argTypes }) => ({
         <el-input v-model="ruleForm.name"></el-input>
       </el-form-item>
       <el-form-item label="Activity zone" prop="region">
-        <el-select v-model="ruleForm.region" placeholder="Activity zone">
-          <el-option label="Zone one" value="shanghai"></el-option>
-          <el-option label="Zone two" value="beijing"></el-option>
-        </el-select>
+        <h-select v-model="ruleForm.region" placeholder="Activity zone" :options=options>
+        </h-select>
       </el-form-item>
       <el-form-item label="Activity time" required>
         <el-col :span="11">


### PR DESCRIPTION
## What is the Purpose?
It Fixes error on HSelect when it is used as a field in a form and set as a required field.

## What was the approach?
Set `selectedValue` to be a computed value

## Are there any concerns to addressed further before or after merging this PR?
State some additional info if any. For instance running `install` or setting some environment variable(s)

## Mentions?
@amosnjoroge 

## Issue(s) affected?
List of issues addressed by this PR. 
