### PR TITLE
Spreadsheet styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hikaya/hakawati",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "repository": {
     "type": "git",
     "url": "https://github.com/hikaya-io/hakawati.git"

--- a/src/components/spreadsheet/HSpreadsheet.vue
+++ b/src/components/spreadsheet/HSpreadsheet.vue
@@ -705,7 +705,7 @@ export default {
 
   /* rectangle style */
   --rectangleBottom: 0;
-  --rectangleHeight: 41px;
+  --rectangleHeight: 100%;
   --rectangleLeft: 0;
   --rectangleRight: 0;
   --rectangleTop: 0;

--- a/src/components/spreadsheet/components/TBody/TBody.scss
+++ b/src/components/spreadsheet/components/TBody/TBody.scss
@@ -4,18 +4,15 @@
   $rectangleBorder: 2px solid $primary-color-sub;
   $rectangleBg: $primary-color-sub-fill;
 
-  $dragToFillSize: 10px;
+  $dragToFillSize: 16px;
   $dragToFillColor: $primary-color-sub;
 
-  $chedkedColor: #b2d1ff;
+  $chedkedColor: $background-color;
 
   .table_row {
-    min-height: 40px;
-    height: 40px;
+    min-height: 41px;
+    height: 41px;
     transition: background ease 0.3s;
-    &:last-child .td {
-      border-bottom: none;
-    }
     &.checked_row {
       background: $chedkedColor;
       td {
@@ -39,7 +36,6 @@
   .td {
     min-height: 41px;
     height: 41px;
-    line-height: 40px;
     position: relative;
     background-color: white;
     border-right: 1px solid $border-grey;
@@ -213,8 +209,8 @@
     }
     .drag_to_fill {
       position: absolute;
-      right: -4px;
-      bottom: -4px;
+      right: -8px;
+      bottom: -8px;
       width: $dragToFillSize;
       height: $dragToFillSize;
       background: $dragToFillColor;

--- a/src/components/spreadsheet/mixins/copyPaste.js
+++ b/src/components/spreadsheet/mixins/copyPaste.js
@@ -409,7 +409,7 @@ export const copyPaste = {
     },
     setRectangleSelection (colMin, colMax, rowMin, rowMax) {
       let width = 100
-      let height = 40
+      let height = 41
 
       // Defined width of rectangle
       if (colMin === 0 && colMax === 0) {
@@ -442,7 +442,7 @@ export const copyPaste = {
       }
 
       this.rectangleSelectedCell.style.setProperty('--rectangleWidth', `${width}%`)
-      this.rectangleSelectedCell.style.setProperty('--rectangleHeight', `${height + (2 * rowMin)}px`)
+      this.rectangleSelectedCell.style.setProperty('--rectangleHeight', `${height}px`)
 
       // Position bottom/top of rectangle if rowStart >= rowEnd
       if (this.selectedCoordCells.rowStart >= this.selectedCoordCells.rowEnd) {

--- a/src/components/spreadsheet/mixins/copyPaste.js
+++ b/src/components/spreadsheet/mixins/copyPaste.js
@@ -446,7 +446,7 @@ export const copyPaste = {
 
       // Position bottom/top of rectangle if rowStart >= rowEnd
       if (this.selectedCoordCells.rowStart >= this.selectedCoordCells.rowEnd) {
-        this.rectangleSelectedCell.style.setProperty('--rectangleTop', 'auto')
+        this.rectangleSelectedCell.style.setProperty('--rectangleTop', 0)
         this.rectangleSelectedCell.style.setProperty('--rectangleBottom', 0)
       } else {
         this.rectangleSelectedCell.style.setProperty('--rectangleTop', 0)

--- a/src/components/spreadsheet/mixins/copyPaste.js
+++ b/src/components/spreadsheet/mixins/copyPaste.js
@@ -442,11 +442,11 @@ export const copyPaste = {
       }
 
       this.rectangleSelectedCell.style.setProperty('--rectangleWidth', `${width}%`)
-      this.rectangleSelectedCell.style.setProperty('--rectangleHeight', `${height}px`)
+      this.rectangleSelectedCell.style.setProperty('--rectangleHeight', `${height - 1}px`)
 
       // Position bottom/top of rectangle if rowStart >= rowEnd
       if (this.selectedCoordCells.rowStart >= this.selectedCoordCells.rowEnd) {
-        this.rectangleSelectedCell.style.setProperty('--rectangleTop', 0)
+        this.rectangleSelectedCell.style.setProperty('--rectangleTop', 'auto')
         this.rectangleSelectedCell.style.setProperty('--rectangleBottom', 0)
       } else {
         this.rectangleSelectedCell.style.setProperty('--rectangleTop', 0)

--- a/src/components/spreadsheet/mixins/helpers.js
+++ b/src/components/spreadsheet/mixins/helpers.js
@@ -7,7 +7,7 @@ export function cleanProperty (element) {
   }
 
   style.setProperty('--rectangleWidth', '100%')
-  style.setProperty('--rectangleHeight', '41px')
+  style.setProperty('--rectangleHeight', '100%')
   style.setProperty('--rectangleTop', 0)
   style.setProperty('--rectangleBottom', 0)
 }

--- a/src/components/spreadsheet/mixins/helpers.js
+++ b/src/components/spreadsheet/mixins/helpers.js
@@ -7,7 +7,7 @@ export function cleanProperty (element) {
   }
 
   style.setProperty('--rectangleWidth', '100%')
-  style.setProperty('--rectangleHeight', '100%')
+  style.setProperty('--rectangleHeight', '41px')
   style.setProperty('--rectangleTop', 0)
   style.setProperty('--rectangleBottom', 0)
 }


### PR DESCRIPTION
## What issue(s) does this PR resolve?

Fixes styling when dragging to fill in the spreadsheet component: 
![image](https://user-images.githubusercontent.com/4407063/220705090-e415804a-36cb-408c-8be6-74a1aa2afab7.png)

## Considerations and implementation

Issues still facing:
- When dragging top to bottom then back up while holding the drag to fill icon, the selected cell jumps by 1 px up.
- When adding multiple rows, it looks like every other row has an additional 1px whitespace at the bottom.

## How to test

  1. Add a few additional rows into the spreadsheet
  2. Select a cell and drag from top to bottom
  3. Hold the drag to fill icon and go back and forth and you can see that the highlighted area is larger than the cells it is highlights

## Test(s) added
N/A

## Mentions?
@michaelbukachi @ninetteadhikari 
